### PR TITLE
Discriminator configuration

### DIFF
--- a/training/config/base/discriminator/config.json
+++ b/training/config/base/discriminator/config.json
@@ -5,6 +5,6 @@
     256
   ],
   "max_hidden_feature_size": 512,
-  "mbstd_group_size": null,
+  "mbstd_group_size": 4,
   "mbstd_num_features": 1
 }

--- a/vit_vqgan/configuration_stylegan_disc.py
+++ b/vit_vqgan/configuration_stylegan_disc.py
@@ -11,7 +11,7 @@ class StyleGANDiscriminatorConfig(PretrainedFromWandbMixin, PretrainedConfig):
         image_size: Union[int, Tuple[int, int]] = (256, 256),
         base_features: int = 32,
         max_hidden_feature_size: int = 512,
-        mbstd_group_size: int = None,
+        mbstd_group_size: int = 4,
         mbstd_num_features: int = 1,
         **kwargs,
     ):


### PR DESCRIPTION
This is mostly a question, I saw in the stylegan2 implementation that they use `mbstd_group_size=4`: 
https://github.com/NVlabs/stylegan2/blob/master/training/networks_stylegan2.py#L625.

In our case, it's set to `None` by default and then we use the batch size: https://github.com/patil-suraj/vit-vqgan/blob/main/vit_vqgan/modeling_stylegan_disc.py#L150.

My questions are:
- Do we need to use `4` as they do? (this PR)
- Do we need a way to disable `minibatch_stddev_layer`?
